### PR TITLE
fix: component analysis displayed only for last duplicate dependency

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -26,7 +26,7 @@ export class Cache {
   add(items: Array<any>): void {
     items.forEach(item => {
       // FIXME: response field is inconsistent when unknown is included.
-      const dep = new SimpleDependency(item.package || item.name, item.version);
+      const dep = new SimpleDependency(item.package || item.name || item.ref.name, item.version || item.ref.version);
       this.cache.set(dep.key(), item);
     });
   }

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -92,7 +92,7 @@ export class Dependency implements IHashableDependency {
   }
 
   key(): string {
-    return `${this.name.value}@${this.version.value}`;
+    return `${this.name.value}@${this.version.value}${this.version.position ? `:${this.version.position.line}` : ''}`;
   }
 }
 
@@ -109,7 +109,11 @@ export class DependencyMap {
      this.mapper = new Map(deps.map(d => [d.key(), d]));
    }
 
-   public get(dep: IHashableDependency): IHashableDependency {
-     return this.mapper.get(dep.key());
+   public get(dep: IHashableDependency): IHashableDependency[] {
+    const regex = new RegExp(`^${dep.key()}:\\d+$`);
+    const keysMatchingRegex = Array.from(this.mapper.keys()).filter(key => regex.test(key));
+    let valsMatchingkeys = []
+    keysMatchingRegex.forEach(key => valsMatchingkeys.push(this.mapper.get(key)))
+    return valsMatchingkeys;
    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -245,16 +245,18 @@ class TotalCount {
 /* Runs DiagnosticPileline to consume response and generate Diagnostic[] */
 function runPipeline(response, diagnostics, packageAggregator, diagnosticFilePath, pkgMap: DependencyMap, totalCount, ecosystem: string) {
     response.forEach(r => {
-        const dependency = (ecosystem === 'maven') ? pkgMap.get(new SimpleDependency( r.ref.name, r.ref.version)) : pkgMap.get(new SimpleDependency( r.package, r.version));
-        let pipeline = new DiagnosticsPipeline(DiagnosticsEngines, dependency, config, diagnostics, packageAggregator, diagnosticFilePath);
-        pipeline.run(r);
-        for (const item of pipeline.items) {
-            const secEng = item as SecurityEngine;
-            totalCount.vulnerabilityCount += secEng.vulnerabilityCount;
-            totalCount.advisoryCount += secEng.advisoryCount;
-            totalCount.exploitCount += secEng.exploitCount;
-            totalCount.issuesCount += secEng.issuesCount;
-        }
+        const dependencies = (ecosystem === 'maven') ? pkgMap.get(new SimpleDependency( r.ref.name, r.ref.version)) : pkgMap.get(new SimpleDependency( r.package, r.version));
+        dependencies.forEach(dependency => {
+            let pipeline = new DiagnosticsPipeline(DiagnosticsEngines, dependency, config, diagnostics, packageAggregator, diagnosticFilePath);
+            pipeline.run(r);
+            for (const item of pipeline.items) {
+                const secEng = item as SecurityEngine;
+                totalCount.vulnerabilityCount += secEng.vulnerabilityCount;
+                totalCount.advisoryCount += secEng.advisoryCount;
+                totalCount.exploitCount += secEng.exploitCount;
+                totalCount.issuesCount += secEng.issuesCount;
+            }
+        })
     });
     connection.sendDiagnostics({ uri: diagnosticFilePath, diagnostics: diagnostics });
     connection.console.log(`sendDiagnostics: ${diagnostics?.length}`);


### PR DESCRIPTION
Bug description:
When the user has the same dependency repeated in pom.xml file, For Component Analysis,
VSCode extension is not throwing warning message for duplicate entries.
Analysis displayed only for the last declaration and the rest of the declarations are being ignored. On the last declaration, the analysis has been repeated for the number of duplicate entries.

Fix:
Displaying warning messages for all duplicate entries.
Analysis recommendation will not be repeated.