### PR TITLE
fix: component analysis should excluded dependencies in dependencyManagement scope

### DIFF
--- a/src/collector/pom.xml.ts
+++ b/src/collector/pom.xml.ts
@@ -54,6 +54,20 @@ export class DependencyCollector implements IDependencyCollector {
         const validElementNames = ['groupId', 'artifactId', 'version'];
         const dependencies = dependenciesNode.subElements.
             filter(e => e.name === 'dependency').
+            //must not be a dependency under dependencyManagement
+            filter(e => {
+                const parentElement = e.parent as XMLElement | undefined;
+                
+                if (parentElement) {
+                  const grandParentElement = parentElement.parent as XMLElement | undefined;
+                  
+                  if (grandParentElement) {
+                    return grandParentElement.name !== 'dependencyManagement';
+                  }
+                }
+                
+                return true;
+            }).
             // must include all validElementNames
             filter(e => e.subElements.filter(e => validElementNames.includes(e.name)).length == validElementNames.length).
             // no test dependencies


### PR DESCRIPTION
Bug description:
LSP server includes dependencies under the pom.xml dependencyManagement scope in the request data for the for the component analysis crda 1.5 endpoint. 

ex:
dependencies such as this, that are under the dependencyManagement scope:
``` 
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>${quarkus.platform.group-id}</groupId>
        <artifactId>${quarkus.platform.artifact-id}</artifactId>
        <version>${quarkus.platform.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
```
are sent in the request data like this:
```
{
  name: "${quarkus.platform.group-id}:${quarkus.platform.artifact-id}",
  version: "2.15.3.Final",
}
```

Fix:
excluded dependencies in dependencyManagement scope from request data in component analysis