### PR TITLE
fix: Detailed Vulnerability Report CodeAction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6508,6 +6508,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -6523,16 +6524,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6547,6 +6551,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -6564,6 +6569,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -16431,7 +16437,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -16444,15 +16451,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -16464,7 +16474,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -16478,7 +16489,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,9 +44,11 @@ documents.listen(connection);
 
 let workspaceRoot: string;
 let crdaHost: string;
+let triggerFullStackAnalysis: string;
 connection.onInitialize((params): InitializeResult => {
     workspaceRoot = params.rootPath;
     crdaHost = params.initializationOptions.crdaHost;
+    triggerFullStackAnalysis = params.initializationOptions.triggerFullStackAnalysis;
     return {
         capabilities: {
             textDocumentSync: documents.syncKind,
@@ -142,14 +144,15 @@ if (fs.existsSync(rc_file)) {
         config.server_url = `${rc.server}/api/v2`;
     }
 }
-const fullStackReportAction: CodeAction = {
+
+const fullStackReportAction = (): CodeAction => ({
   title: 'Detailed Vulnerability Report',
   kind: CodeActionKind.QuickFix,
   command: {
-    command: 'extension.fabric8AnalyticsWidgetFullStack',
+    command: triggerFullStackAnalysis,
     title: 'Analytics Report',
   }
-};
+});
 
 let DiagnosticsEngines = [SecurityEngine];
 
@@ -411,7 +414,7 @@ connection.onCodeAction((params, token): CodeAction[] => {
         }
     }
     if (config.provide_fullstack_action && hasAnalyticsDiagonostic) {
-        codeActions.push(fullStackReportAction);
+        codeActions.push(fullStackReportAction());
     }
     return codeActions;
 });


### PR DESCRIPTION
Bug description:
While each marked dependency presents a 'Detailed Vulnerability Report' option in the QuickFix section,
by clicking on the 'Detailed Vulnerability Report' option, no dependency report is rendered and instead an error is prompted explaining that the requested command cannot be found. 

Fix description:
The command trigger for the Full Stack Analysis CodeAction set up in the late LSP server has been hardcoded and no longer in use. 
As a solution, the new command trigger will be transferred from the LSP client to the LSP server via IPC initializationOptions and will no longer be hard coded in the LSP server, thus rendering the 'Detailed Vulnerability Report' as requested.