### PR TITLE
fix: effective-pom fixes

### DIFF
--- a/src/collector/pom.xml.ts
+++ b/src/collector/pom.xml.ts
@@ -8,11 +8,11 @@ export class DependencyCollector implements IDependencyCollector {
     private xmlDocAst: XMLDocument;
     private originalDeps: Array<XMLElement>;
 
-    constructor(originalContents: string, public classes: Array<string> = ["dependencies"]) {
+    constructor(originalContents: string, enforceVersions: boolean, public classes: Array<string> = ["dependencies"]) {
         const { cst, tokenVector } = parse(originalContents);
         const originalXmlDocAst = buildAst(cst as DocumentCstNode, tokenVector);
         if (originalXmlDocAst.rootElement) {
-            this.originalDeps = this.getXMLDependencies(originalXmlDocAst, false);
+            this.originalDeps = this.getXMLDependencies(originalXmlDocAst, enforceVersions);
         }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -412,7 +412,7 @@ const sendDiagnostics = async (ecosystem: string, diagnosticFilePath: string, co
 };
 
 function sendDiagnosticsWithEffectivePom(uri, original: string) {
-    let tempTarget = uri.replace('file://', '').replace('pom.xml', '');
+    let tempTarget = uri.replace('file://', '').replaceAll('%20', ' ').replace('pom.xml', '');
     const effectivePomPath = path.join(tempTarget, 'target', 'effective-pom.xml');
     const tmpPomPath = path.join(tempTarget, 'target', 'in-memory-pom.xml');
     fs.writeFile(tmpPomPath, original, (error) => {
@@ -420,7 +420,7 @@ function sendDiagnosticsWithEffectivePom(uri, original: string) {
             server.connection.sendNotification('caError', error);
         } else {
             try {
-                execSync(`${globalSettings.mvnExecutable} help:effective-pom -Doutput=${effectivePomPath} --quiet -f ${tmpPomPath}`);
+                execSync(`${globalSettings.mvnExecutable} help:effective-pom -Doutput='${effectivePomPath}' --quiet -f '${tmpPomPath}'`);
                 try {
                     const data = fs.readFileSync(effectivePomPath, 'utf8');
                     sendDiagnostics('maven', uri, data, new PomXml(original));

--- a/src/server.ts
+++ b/src/server.ts
@@ -423,7 +423,7 @@ function sendDiagnosticsWithEffectivePom(uri, original: string) {
                 execSync(`${globalSettings.mvnExecutable} help:effective-pom -Doutput='${effectivePomPath}' --quiet -f '${tmpPomPath}'`);
                 try {
                     const data = fs.readFileSync(effectivePomPath, 'utf8');
-                    sendDiagnostics('maven', uri, data, new PomXml(original));
+                    sendDiagnostics('maven', uri, data, new PomXml(original, false));
                 } catch (error) {
                     server.connection.sendNotification('caError', error.message);
                 }
@@ -431,7 +431,7 @@ function sendDiagnosticsWithEffectivePom(uri, original: string) {
                 // Ignore. Non parseable pom and fall back to original content
                 server.connection.sendNotification('caSimpleWarning', "Full component analysis cannot be performed until the Pom is valid.");
                 connection.console.info("Unable to parse effective pom. Cause: " + error.message);
-                sendDiagnostics('maven', uri, original, new PomXml(original));
+                sendDiagnostics('maven', uri, original, new PomXml(original, true));
             } finally {
                 if (fs.existsSync(tmpPomPath)) {
                     fs.rmSync(tmpPomPath);

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -24,7 +24,7 @@ describe('Collector util test', () => {
 
   it('create map', async () => {
     const map = new DependencyMap(reqDeps);
-    expect(map.get(resDeps[0])).to.eql([reqDeps[0]]);
-    expect(map.get(resDeps[1])).to.eql([reqDeps[1]]);
+    expect(map.get(resDeps[0])).to.eql(reqDeps[0]);
+    expect(map.get(resDeps[1])).to.eql(reqDeps[1]);
   });
 })

--- a/test/collector/pom.xml.test.ts
+++ b/test/collector/pom.xml.test.ts
@@ -8,7 +8,7 @@ describe('Maven pom.xml parser test', () => {
     it('tests pom.xml with empty string', async () => {
         const pom = `
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps.length).equal(0);
     });
 
@@ -17,7 +17,7 @@ describe('Maven pom.xml parser test', () => {
 
         </project>
        `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps.length).equal(0);
     });
 
@@ -28,7 +28,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
         </project>
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps.length).equal(0);
     });
 
@@ -50,7 +50,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps).is.eql([{
             name: { value: 'foo:bar', position: { line: 10, column: 17 } },
             version: { value: '2.4', position: { line: 13, column: 30 } },
@@ -98,7 +98,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(original).collect(effective);
+        const deps = await new DependencyCollector(original, false).collect(effective);
         expect(deps).is.eql([{
             name: { value: 'foo:bar', position: { line: 10, column: 17 } },
             version: { value: '2.4', position: { line: 13, column: 30 } },
@@ -148,7 +148,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(original).collect(effective);
+        const deps = await new DependencyCollector(original, false).collect(effective);
         expect(deps).is.eql([{
             name: { value: 'foo:bar', position: { line: 10, column: 17 } },
             version: { value: '2.4', position: { line: 13, column: 30 } },
@@ -213,7 +213,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(original).collect(effective);
+        const deps = await new DependencyCollector(original, false).collect(effective);
         expect(deps).is.eql([{
             name: { value: 'foo:bar', position: { line: 10, column: 17 } },
             version: { value: '2.4', position: { line: 0, column: 0 } },
@@ -281,7 +281,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps).is.eql([{
             name: { value: 'plugins:a', position: { line: 5, column: 21 } },
             version: { value: '2.3', position: { line: 8, column: 34 } }
@@ -323,7 +323,7 @@ describe('Maven pom.xml parser test', () => {
                 </dependencies>
             </project>
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps.length).equal(0);
     });
 
@@ -353,7 +353,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps).is.eql([{
             name: { value: 'c:ab-cd', position: { line: 4, column: 17 } },
             version: { value: '2.3', position: { line: 7, column: 30 } }
@@ -397,7 +397,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps).is.eql([{
             name: { value: 'c:ab-cd', position: { line: 21, column: 17 } },
             version: { value: '2.3', position: { line: 24, column: 30 } }
@@ -459,7 +459,7 @@ describe('Maven pom.xml parser test', () => {
             </dependencies>
          </project>
         `;
-        const deps = await new DependencyCollector(original).collect(effective);
+        const deps = await new DependencyCollector(original, false).collect(effective);
         expect(deps).is.eql([{
             name: { value: 'c:ab-cd', position: { line: 4, column: 17 } },
             version: { value: '2.3', position: { line: 7, column: 30 } }
@@ -526,7 +526,37 @@ describe('Maven pom.xml parser test', () => {
             </dependencyManagement>
          </project>
         `;
-        const deps = await new DependencyCollector(pom).collect(pom);
+        const deps = await new DependencyCollector(pom, false).collect(pom);
         expect(deps.length).equal(0);
+    });
+
+    it('ignores versions when the effective pom is not valid', async () => {
+        const original = `
+        <project>
+            <dependencies>
+                <dependency>
+                    <groupId>c</groupId>
+                    <artifactId>ab-cd</artifactId>
+                    <version>2.3</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>foo</groupId>
+                    <artifactId>bar</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>foo</groupId>
+                    <artifactId>baz</artifactId>
+                    <version>2.4</version>
+                </dependency>
+            </dependencies>
+         </project>
+        `;
+
+        const deps = await new DependencyCollector(original, true).collect(original);
+        expect(deps).is.eql([{
+            name: { value: 'foo:baz', position: { line: 14, column: 17 } },
+            version: { value: '2.4', position: { line: 17, column: 30 } }
+        }]);
     });
 });


### PR DESCRIPTION
- Allow folders with spaces
- Filter out dependencies without versions when `mvn help:effective-pom` fails

Follow up on #7 